### PR TITLE
Root object mappings

### DIFF
--- a/classes/api.php
+++ b/classes/api.php
@@ -4,8 +4,9 @@ namespace Icspresso;
 
 use Icspresso\Transports\WP_HTTP;
 use Icspresso\Transports\WP_HTTPS;
+use ElasticSearch\Client;
 
-class API extends \ElasticSearch\Client {
+class API extends Client {
 
 	/**
 	 * Hacked in due to private {transport} ref on \ElasticSearch\Client
@@ -144,7 +145,7 @@ class API extends \ElasticSearch\Client {
 			$port = $this->configuration->get_port();
 			$timeout = $this->configuration->get_timeout();
 
-			if(strtolower($protocol) == 'https') {
+			if ( strtolower( $protocol ) === 'https' ) {
 
 				$this->transport_ref = new WP_HTTPS( $host, $port, $timeout );
 
@@ -153,7 +154,6 @@ class API extends \ElasticSearch\Client {
 				$this->transport_ref = new WP_HTTP( $host, $port, $timeout );
 
 			}
-
 		}
 
 		return $this->transport_ref;
@@ -166,5 +166,20 @@ class API extends \ElasticSearch\Client {
 	 */
 	public function createBulk() {
 		return new Transports\Bulk( $this );
+	}
+
+	/**
+	 * Puts a mapping on index, overwriting so we can add root level config
+	 *
+	 * @param array|object $mapping
+	 * @param array        $config
+	 * @return array
+	 */
+	public function map( $mapping, array $config = array() ) {
+		if ( is_array( $mapping ) ) {
+			$mapping = new Mapping( $mapping );
+		}
+
+		return parent::map( $mapping, $config );
 	}
 }

--- a/classes/mapping.php
+++ b/classes/mapping.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Icspresso;
+
+class Mapping extends \ElasticSearch\Mapping {
+
+	/**
+	 * Export mapping data as a json-ready array
+	 *
+	 * @return string
+	 */
+	public function export() {
+
+		$root_object = apply_filters( 'icspresso_root_mapping_' . $this->config['type'], array() );
+		$root_object['properties'] = $this->properties;
+
+		return $root_object;
+	}
+
+}

--- a/classes/mapping.php
+++ b/classes/mapping.php
@@ -11,7 +11,26 @@ class Mapping extends \ElasticSearch\Mapping {
 	 */
 	public function export() {
 
-		$root_object = apply_filters( 'icspresso_root_mapping_' . $this->config['type'], array() );
+		$root_object = apply_filters( 'icspresso_root_mapping_' . $this->config['type'], array(
+			'numeric_detection'    => true,
+			'dynamic_date_formats' => array(
+				'yyyy-MM-dd HH:mm:ss',
+				'yyyy-MM-dd',
+			),
+			'dynamic_templates'    => array(
+				array(
+					'meta_template_1' => array(
+						'path_match'         => 'meta.*',
+						'match_mapping_type' => 'string',
+						'mapping'            => array(
+							'index' => 'not_analyzed',
+							'type'  => 'string',
+						),
+					),
+				),
+			),
+		) );
+
 		$root_object['properties'] = $this->properties;
 
 		return $root_object;

--- a/classes/mapping.php
+++ b/classes/mapping.php
@@ -2,7 +2,9 @@
 
 namespace Icspresso;
 
-class Mapping extends \ElasticSearch\Mapping {
+use ElasticSearch\Mapping as Mapping_Base;
+
+class Mapping extends Mapping_Base {
 
 	/**
 	 * Export mapping data as a json-ready array

--- a/icspresso.php
+++ b/icspresso.php
@@ -17,6 +17,7 @@ include_dir( __DIR__ . '/classes/types' );
 
 require_once( __DIR__ . '/icspresso-admin.php' );
 require_once( __DIR__ . '/classes/api.php' );
+require_once( __DIR__ . '/classes/mapping.php' );
 require_once( __DIR__ . '/classes/configuration.php' );
 require_once( __DIR__ . '/classes/logger.php' );
 require_once( __DIR__ . '/classes/master.php' );


### PR DESCRIPTION
Root level object mappings allow us to create sensible defaults for metadata and other fields that match dates or ints for example.